### PR TITLE
gcs: Use Int63 to do delay sampling

### DIFF
--- a/gcs/retry.go
+++ b/gcs/retry.go
@@ -113,7 +113,7 @@ func chooseDelay(prevSleepCount uint) (d time.Duration) {
 
 	// Choose a a delay in [0, 2^prevSleepCount * baseDelay).
 	d = (1 << prevSleepCount) * baseDelay
-	d = time.Duration(float64(d) * rand.Float64())
+	d = time.Duration(rand.Int63n(int64(d)))
 
 	return
 }


### PR DESCRIPTION
This way seems cleaner, since we never leave the space of the int64 type.

I'd have refactored to remove the var `d` altogether, but that's cosmetic.
