### PR TITLE
Print the prefix from ListObject request in debug_bucket

### DIFF
--- a/gcs/debug_bucket.go
+++ b/gcs/debug_bucket.go
@@ -201,7 +201,7 @@ func (b *debugBucket) StatObject(
 func (b *debugBucket) ListObjects(
 	ctx context.Context,
 	req *ListObjectsRequest) (listing *Listing, err error) {
-	id, desc, start := b.startRequest("ListObjects()")
+	id, desc, start := b.startRequest("ListObjects(%q)", req.Prefix)
 	defer b.finishRequest(id, desc, start, &err)
 
 	listing, err = b.wrapped.ListObjects(ctx, req)


### PR DESCRIPTION
The debug_bucket is used to print debug messages of the GCS requests. Almost all the requests would contain the object name, such as 
```golang
b.startRequest("StatObject(%q)", req.Name)
```

However, the message for ListObject contains no object name. This PR adds the prefix of the request into the message to improve the debug experience.