### PR TITLE
Allow overriding the GCS URL

### DIFF
--- a/gcs/bucket.go
+++ b/gcs/bucket.go
@@ -125,6 +125,7 @@ type Bucket interface {
 
 type bucket struct {
 	client         *http.Client
+	url            *url.URL
 	userAgent      string
 	name           string
 	billingProject string
@@ -139,7 +140,8 @@ func (b *bucket) ListObjects(
 	req *ListObjectsRequest) (listing *Listing, err error) {
 	// Construct an appropriate URL (cf. http://goo.gl/aVSAhT).
 	opaque := fmt.Sprintf(
-		"//www.googleapis.com/storage/v1/b/%s/o",
+		"//%s/storage/v1/b/%s/o",
+		b.url.Host,
 		httputil.EncodePathSegment(b.Name()))
 
 	query := make(url.Values)
@@ -166,8 +168,8 @@ func (b *bucket) ListObjects(
 	}
 
 	url := &url.URL{
-		Scheme:   "https",
-		Host:     "www.googleapis.com",
+		Scheme:   b.url.Scheme,
+		Host:     b.url.Host,
 		Opaque:   opaque,
 		RawQuery: query.Encode(),
 	}
@@ -211,7 +213,8 @@ func (b *bucket) StatObject(
 	req *StatObjectRequest) (o *Object, err error) {
 	// Construct an appropriate URL (cf. http://goo.gl/MoITmB).
 	opaque := fmt.Sprintf(
-		"//www.googleapis.com/storage/v1/b/%s/o/%s",
+		"//%s/storage/v1/b/%s/o/%s",
+		b.url.Host,
 		httputil.EncodePathSegment(b.Name()),
 		httputil.EncodePathSegment(req.Name))
 
@@ -223,8 +226,8 @@ func (b *bucket) StatObject(
 	}
 
 	url := &url.URL{
-		Scheme:   "https",
-		Host:     "www.googleapis.com",
+		Scheme:   b.url.Scheme,
+		Host:     b.url.Host,
 		Opaque:   opaque,
 		RawQuery: query.Encode(),
 	}
@@ -276,7 +279,8 @@ func (b *bucket) DeleteObject(
 	req *DeleteObjectRequest) (err error) {
 	// Construct an appropriate URL (cf. http://goo.gl/TRQJjZ).
 	opaque := fmt.Sprintf(
-		"//www.googleapis.com/storage/v1/b/%s/o/%s",
+		"//%s/storage/v1/b/%s/o/%s",
+		b.url.Host,
 		httputil.EncodePathSegment(b.Name()),
 		httputil.EncodePathSegment(req.Name))
 
@@ -297,8 +301,8 @@ func (b *bucket) DeleteObject(
 	}
 
 	url := &url.URL{
-		Scheme:   "https",
-		Host:     "www.googleapis.com",
+		Scheme:   b.url.Scheme,
+		Host:     b.url.Host,
 		Opaque:   opaque,
 		RawQuery: query.Encode(),
 	}
@@ -345,11 +349,13 @@ func (b *bucket) DeleteObject(
 
 func newBucket(
 	client *http.Client,
+	url *url.URL,
 	userAgent string,
 	name string,
 	billingProject string) Bucket {
 	return &bucket{
 		client:         client,
+		url:            url,
 		userAgent:      userAgent,
 		name:           name,
 		billingProject: billingProject,

--- a/gcs/compose_objects.go
+++ b/gcs/compose_objects.go
@@ -77,7 +77,8 @@ func (b *bucket) ComposeObjects(
 	objectSegment := httputil.EncodePathSegment(req.DstName)
 
 	opaque := fmt.Sprintf(
-		"//www.googleapis.com/storage/v1/b/%s/o/%s/compose",
+		"//%s/storage/v1/b/%s/o/%s/compose",
+		b.url.Host,
 		bucketSegment,
 		objectSegment)
 
@@ -94,8 +95,8 @@ func (b *bucket) ComposeObjects(
 	}
 
 	url := &url.URL{
-		Scheme:   "https",
-		Host:     "www.googleapis.com",
+		Scheme:   b.url.Scheme,
+		Host:     b.url.Host,
 		Opaque:   opaque,
 		RawQuery: query.Encode(),
 	}

--- a/gcs/copy_object.go
+++ b/gcs/copy_object.go
@@ -42,7 +42,8 @@ func (b *bucket) CopyObject(
 
 	// Construct an appropriate URL (cf. https://goo.gl/A41CyJ).
 	opaque := fmt.Sprintf(
-		"//www.googleapis.com/storage/v1/b/%s/o/%s/copyTo/b/%s/o/%s",
+		"//%s/storage/v1/b/%s/o/%s/copyTo/b/%s/o/%s",
+		b.url.Host,
 		httputil.EncodePathSegment(b.Name()),
 		httputil.EncodePathSegment(req.SrcName),
 		httputil.EncodePathSegment(b.Name()),
@@ -62,8 +63,8 @@ func (b *bucket) CopyObject(
 	}
 
 	url := &url.URL{
-		Scheme:   "https",
-		Host:     "www.googleapis.com",
+		Scheme:   b.url.Scheme,
+		Host:     b.url.Host,
 		Opaque:   opaque,
 		RawQuery: query.Encode(),
 	}

--- a/gcs/create_object.go
+++ b/gcs/create_object.go
@@ -66,7 +66,8 @@ func (b *bucket) startResumableUpload(
 	// 3986.
 	bucketSegment := httputil.EncodePathSegment(b.Name())
 	opaque := fmt.Sprintf(
-		"//www.googleapis.com/upload/storage/v1/b/%s/o",
+		"//%s/upload/storage/v1/b/%s/o",
+		b.url.Host,
 		bucketSegment)
 
 	query := make(url.Values)
@@ -84,8 +85,8 @@ func (b *bucket) startResumableUpload(
 	}
 
 	url := &url.URL{
-		Scheme:   "https",
-		Host:     "www.googleapis.com",
+		Scheme:   b.url.Scheme,
+		Host:     b.url.Host,
 		Opaque:   opaque,
 		RawQuery: query.Encode(),
 	}

--- a/gcs/read.go
+++ b/gcs/read.go
@@ -44,7 +44,8 @@ func (b *bucket) NewReader(
 	bucketSegment := httputil.EncodePathSegment(b.name)
 	objectSegment := httputil.EncodePathSegment(req.Name)
 	opaque := fmt.Sprintf(
-		"//www.googleapis.com/download/storage/v1/b/%s/o/%s",
+		"//%s/download/storage/v1/b/%s/o/%s",
+		b.url.Host,
 		bucketSegment,
 		objectSegment)
 
@@ -60,8 +61,8 @@ func (b *bucket) NewReader(
 	}
 
 	url := &url.URL{
-		Scheme:   "https",
-		Host:     "www.googleapis.com",
+		Scheme:   b.url.Scheme,
+		Host:     b.url.Host,
 		Opaque:   opaque,
 		RawQuery: query.Encode(),
 	}

--- a/gcs/update_object.go
+++ b/gcs/update_object.go
@@ -86,7 +86,8 @@ func (b *bucket) UpdateObject(
 	req *UpdateObjectRequest) (o *Object, err error) {
 	// Construct an appropriate URL (cf. http://goo.gl/B46IDy).
 	opaque := fmt.Sprintf(
-		"//www.googleapis.com/storage/v1/b/%s/o/%s",
+		"//%s/storage/v1/b/%s/o/%s",
+		b.url.Host,
 		httputil.EncodePathSegment(b.Name()),
 		httputil.EncodePathSegment(req.Name))
 
@@ -104,8 +105,8 @@ func (b *bucket) UpdateObject(
 	}
 
 	url := &url.URL{
-		Scheme:   "https",
-		Host:     "www.googleapis.com",
+		Scheme:   b.url.Scheme,
+		Host:     b.url.Host,
 		Opaque:   opaque,
 		RawQuery: query.Encode(),
 	}


### PR DESCRIPTION
This allows use of other implementations like fake-gcs-server.  Modify the
TokenSource check since this is absent with non-GCS servers.