### PR TITLE
Support IncludeTrailingDelimiter field in ListObjects request

### DIFF
--- a/gcs/bucket.go
+++ b/gcs/bucket.go
@@ -153,6 +153,8 @@ func (b *bucket) ListObjects(
 
 	if req.Delimiter != "" {
 		query.Set("delimiter", req.Delimiter)
+		query.Set("includeTrailingDelimiter",
+			fmt.Sprintf("%v", req.IncludeTrailingDelimiter))
 	}
 
 	if req.ContinuationToken != "" {

--- a/gcs/requests.go
+++ b/gcs/requests.go
@@ -196,6 +196,22 @@ type ListObjectsRequest struct {
 	// a large number of objects, this may be more efficient.
 	Delimiter string
 
+	// Only applicable when Delimiter is set nonempty. Default to false.
+	//
+	// The objects in the result listing would contain those objects that end
+	// with the first delimiter if this is true. Otherwise, those objects are
+	// not included.
+	//
+	// Example:
+	//  Assume there is an object "foo/bar/".
+	//  1. Prefix: "foo/", Delimiter: "/", IncludeTrailingDelimiter: true
+	//     -> "foo/bar/" exists in both listing.CollapsedRuns and
+	//     listing.Objects.
+	//  2. Prefix: "foo/", Delimiter: "/", IncludeTrailingDelimiter: false
+	//     -> "foo/bar/" exists in only listing.CollapsedRuns but not
+	//     listing.Objects.
+	IncludeTrailingDelimiter bool
+
 	// Used to continue a listing where a previous one left off. See
 	// Listing.ContinuationToken for more information.
 	ContinuationToken string


### PR DESCRIPTION
The field IncludeTrailingDelimiter is available in the [objects.list API spec](https://cloud.google.com/storage/docs/json_api/v1/objects/list#parameters) but not supported in this library. It can help reduce the overhead of syncing implicit directories in the buckets. Therefore, this PR adds this valuable field into the ListObjectsRequest in the library. 