### PR TITLE
Reduce noise in the retry logs

### DIFF
--- a/gcs/retry.go
+++ b/gcs/retry.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"math"
 	"math/rand"
 	"net"
@@ -157,12 +156,7 @@ func expBackoff(
 			// Special case: don't spam up the logs for EOF, which io.Reader returns
 			// in the normal course of things.
 			if err != io.EOF {
-				log.Printf(
-					"Not retrying %s after error of type %T (%q): %#v",
-					desc,
-					err,
-					err.Error(),
-					err)
+				err = fmt.Errorf("not retrying %s: %w", desc, err)
 			}
 
 			return
@@ -179,13 +173,6 @@ func expBackoff(
 		}
 
 		// Sleep, returning early if cancelled.
-		log.Printf(
-			"Retrying %s after error of type %T (%q) in %v",
-			desc,
-			err,
-			err,
-			d)
-
 		select {
 		case <-ctx.Done():
 			// On cancellation, return the last error we saw.


### PR DESCRIPTION
When `retry` is used in the client library, it prints out a huge number of logs even when there is nothing unexpected. For instance, it's common to run StatObject to test if an object exists. When the object does not exist, such call would print a log 

```
Not retrying StatObject("Some/File/Or/Folder/") after error of type *gcs.NotFoundError ("gcs.NotFoundError: googleapi: Error 404: No such object: Some/File/Or/Folder/, notFound"): &gcs.NotFoundError{Err:(*googleapi.Error)(0xc0000a4360)}
``` 

This PR removes these useless logs.