### PR TITLE
Adding projection param to ListObjects request.

### DIFF
--- a/gcs/bucket.go
+++ b/gcs/bucket.go
@@ -145,7 +145,7 @@ func (b *bucket) ListObjects(
 		httputil.EncodePathSegment(b.Name()))
 
 	query := make(url.Values)
-	query.Set("projection", "full")
+	query.Set("projection", req.ProjectionVal.String())
 
 	if req.Prefix != "" {
 		query.Set("prefix", req.Prefix)

--- a/gcs/requests.go
+++ b/gcs/requests.go
@@ -192,7 +192,7 @@ func (p Projection) String() string {
 	case NoAcl:
 		return "noAcl"
 	}
-	return "noAcl"
+	return "full"
 }
 
 type ListObjectsRequest struct {

--- a/gcs/requests.go
+++ b/gcs/requests.go
@@ -176,6 +176,25 @@ type StatObjectRequest struct {
 	Name string
 }
 
+type Projection int64
+
+const (
+	Full Projection = iota
+	NoAcl
+)
+
+// Returning the string values based on the values accepted by projection param.
+// https://cloud.google.com/storage/docs/json_api/v1/objects/list#parameters
+func (p Projection) String() string {
+	switch p {
+	case Full:
+		return "full"
+	case NoAcl:
+		return "noAcl"
+	}
+	return "noAcl"
+}
+
 type ListObjectsRequest struct {
 	// List only objects whose names begin with this prefix.
 	Prefix string
@@ -220,6 +239,15 @@ type ListObjectsRequest struct {
 	// this number may actually be returned. If this is zero, a sensible default
 	// is used.
 	MaxResults int
+
+	// Set of properties to return. Acceptable values- full & noAcl.
+	//    1. full  - returns all properties
+	//    2. noAcl - omit owner, acl properties
+	//
+	// Currently projection value is hardcoded to full. To keep it aligned with
+	// the current flow, default value will be full and callers can override it
+	// using this param.
+	ProjectionVal Projection
 }
 
 // Listing contains a set of objects and delimter-based collapsed runs returned


### PR DESCRIPTION
Right now projection param is hardcoded to full which returns owner and acls information as well. Returning acls require extra processing by GCS and results in higher latency. Owner and acls are not required in all flows. Hence adding projection param for the caller to decided on what to fetch.

Setting the default value as full to keep it consistent with existing behaviour.