### PR TITLE
Adding all object properties to CreateObject and ComposeObject requests

### DIFF
--- a/gcs/compose_objects.go
+++ b/gcs/compose_objects.go
@@ -36,9 +36,16 @@ func (b *bucket) makeComposeObjectsBody(
 	// Create a request in the form expected by the API.
 	r := storagev1.ComposeRequest{
 		Destination: &storagev1.Object{
-			Name:        req.DstName,
-			ContentType: req.ContentType,
-			Metadata:    req.Metadata,
+			Name:               req.DstName,
+			ContentType:        req.ContentType,
+			Metadata:           req.Metadata,
+			CacheControl:       req.CacheControl,
+			ContentDisposition: req.ContentDisposition,
+			ContentLanguage:    req.ContentLanguage,
+			ContentEncoding:    req.ContentEncoding,
+			CustomTime:         req.CustomTime,
+			EventBasedHold:     req.EventBasedHold,
+			StorageClass:       req.StorageClass,
 		},
 	}
 

--- a/gcs/conversions.go
+++ b/gcs/conversions.go
@@ -68,18 +68,21 @@ func toListing(in *storagev1.Objects) (out *Listing, err error) {
 func toObject(in *storagev1.Object) (out *Object, err error) {
 	// Convert the easy fields.
 	out = &Object{
-		Name:            in.Name,
-		ContentType:     in.ContentType,
-		ContentLanguage: in.ContentLanguage,
-		CacheControl:    in.CacheControl,
-		ContentEncoding: in.ContentEncoding,
-		ComponentCount:  in.ComponentCount,
-		Size:            in.Size,
-		MediaLink:       in.MediaLink,
-		Metadata:        in.Metadata,
-		Generation:      in.Generation,
-		MetaGeneration:  in.Metageneration,
-		StorageClass:    in.StorageClass,
+		Name:               in.Name,
+		ContentType:        in.ContentType,
+		ContentLanguage:    in.ContentLanguage,
+		CacheControl:       in.CacheControl,
+		ContentDisposition: in.ContentDisposition,
+		ContentEncoding:    in.ContentEncoding,
+		ComponentCount:     in.ComponentCount,
+		Size:               in.Size,
+		MediaLink:          in.MediaLink,
+		Metadata:           in.Metadata,
+		Generation:         in.Generation,
+		MetaGeneration:     in.Metageneration,
+		StorageClass:       in.StorageClass,
+		CustomTime:         in.CustomTime,
+		EventBasedHold:     in.EventBasedHold,
 	}
 
 	// Work around Google-internal bug 21572928. See notes on the ComponentCount
@@ -160,13 +163,17 @@ func toRawObject(
 	bucketName string,
 	in *CreateObjectRequest) (out *storagev1.Object, err error) {
 	out = &storagev1.Object{
-		Bucket:          bucketName,
-		Name:            in.Name,
-		ContentType:     in.ContentType,
-		ContentLanguage: in.ContentLanguage,
-		ContentEncoding: in.ContentEncoding,
-		CacheControl:    in.CacheControl,
-		Metadata:        in.Metadata,
+		Bucket:             bucketName,
+		Name:               in.Name,
+		ContentType:        in.ContentType,
+		ContentLanguage:    in.ContentLanguage,
+		ContentEncoding:    in.ContentEncoding,
+		CacheControl:       in.CacheControl,
+		Metadata:           in.Metadata,
+		ContentDisposition: in.ContentDisposition,
+		CustomTime:         in.CustomTime,
+		EventBasedHold:     in.EventBasedHold,
+		StorageClass:       in.StorageClass,
 	}
 
 	if in.CRC32C != nil {

--- a/gcs/object.go
+++ b/gcs/object.go
@@ -64,4 +64,8 @@ type Object struct {
 	// the officially documented behavior above. That is, it synthesizes a
 	// component count of 1 for objects that do not have a component count.
 	ComponentCount int64
+
+	ContentDisposition string
+	CustomTime         string
+	EventBasedHold     bool
 }

--- a/gcs/requests.go
+++ b/gcs/requests.go
@@ -41,11 +41,15 @@ type CreateObjectRequest struct {
 	//
 	//     https://cloud.google.com/storage/docs/json_api/v1/objects#resource
 	//
-	ContentType     string
-	ContentLanguage string
-	ContentEncoding string
-	CacheControl    string
-	Metadata        map[string]string
+	ContentType        string
+	ContentLanguage    string
+	ContentEncoding    string
+	CacheControl       string
+	Metadata           map[string]string
+	ContentDisposition string
+	CustomTime         string
+	EventBasedHold     bool
+	StorageClass       string
 
 	// A reader from which to obtain the contents of the object. Must be non-nil.
 	Contents io.Reader
@@ -125,8 +129,15 @@ type ComposeObjectsRequest struct {
 	//
 	//     https://cloud.google.com/storage/docs/json_api/v1/objects#resource
 	//
-	ContentType string
-	Metadata    map[string]string
+	ContentType        string
+	Metadata           map[string]string
+	ContentLanguage    string
+	ContentEncoding    string
+	CacheControl       string
+	ContentDisposition string
+	CustomTime         string
+	EventBasedHold     bool
+	StorageClass       string
 }
 
 type ComposeSource struct {


### PR DESCRIPTION
1. Adding all object properties to CreateObject and ComposeObject requests. This will enable users to set these properties while creating/composing an object.
2. Handling these properties while converting from storage proto to local proto and viceversa
Issue: https://github.com/GoogleCloudPlatform/gcsfuse/issues/648