### PR TITLE
Added field to StatObjectRequest to control fetching from cache

### DIFF
--- a/gcs/requests.go
+++ b/gcs/requests.go
@@ -174,6 +174,10 @@ type ReadObjectRequest struct {
 type StatObjectRequest struct {
 	// The name of the object in question.
 	Name string
+
+	// Relevant only when fast_stat_bucket is used. This field controls whether
+	// to fetch from gcs or from cache.
+	ForceFetchFromGcs bool
 }
 
 type Projection int64


### PR DESCRIPTION
Sometimes when we know that cache doesn't have complete or latest data, we want to fetch from gcs instead of using cache object.  Adding support for the same.

https://github.com/GoogleCloudPlatform/gcsfuse/issues/648