### PR TITLE
Include the userProject query param in more calls to GCS when using requester pays bucket.

### DIFF
--- a/gcs/compose_objects.go
+++ b/gcs/compose_objects.go
@@ -102,6 +102,10 @@ func (b *bucket) ComposeObjects(
 			fmt.Sprint(*req.DstMetaGenerationPrecondition))
 	}
 
+	if b.billingProject != "" {
+		query.Set("userProject", b.billingProject)
+	}
+
 	url := &url.URL{
 		Scheme:   b.url.Scheme,
 		Host:     b.url.Host,

--- a/gcs/copy_object.go
+++ b/gcs/copy_object.go
@@ -62,6 +62,10 @@ func (b *bucket) CopyObject(
 			fmt.Sprintf("%d", *req.SrcMetaGenerationPrecondition))
 	}
 
+	if b.billingProject != "" {
+		query.Set("userProject", b.billingProject)
+	}
+
 	url := &url.URL{
 		Scheme:   b.url.Scheme,
 		Host:     b.url.Host,

--- a/gcs/create_object.go
+++ b/gcs/create_object.go
@@ -84,6 +84,10 @@ func (b *bucket) startResumableUpload(
 			fmt.Sprint(*req.MetaGenerationPrecondition))
 	}
 
+	if b.billingProject != "" {
+		query.Set("userProject", b.billingProject)
+	}
+
 	url := &url.URL{
 		Scheme:   b.url.Scheme,
 		Host:     b.url.Host,

--- a/gcs/update_object.go
+++ b/gcs/update_object.go
@@ -104,6 +104,10 @@ func (b *bucket) UpdateObject(
 			fmt.Sprintf("%d", *req.MetaGenerationPrecondition))
 	}
 
+	if b.billingProject != "" {
+		query.Set("userProject", b.billingProject)
+	}
+
 	url := &url.URL{
 		Scheme:   b.url.Scheme,
 		Host:     b.url.Host,


### PR DESCRIPTION
When requester pays bucket is on, we need to set the userProject param in all the requests. This PR adds it to the missing files. This is in response to the GCSFuse issue 659