### PR TITLE
Upgrading go from 1.18 to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jacobsa/gcloud
 
-go 1.18
+go 1.19
 
 require (
 	github.com/jacobsa/fuse v0.0.0-20211125163655-ffd6c474e806


### PR DESCRIPTION
We want to upgrade go version in GCSFuse and want to upgrade go version in jacobsa/gcloud before that https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/go.mod