### PR TITLE
Adding DstGenerationPrecondition to CopyObject

### DIFF
--- a/gcs/requests.go
+++ b/gcs/requests.go
@@ -90,11 +90,6 @@ type CopyObjectRequest struct {
 	//
 	// This is probably only meaningful in conjunction with SrcGeneration.
 	SrcMetaGenerationPrecondition *int64
-
-	// Destination object will be overwritten only if the current
-	// generation is equal to the given value. Zero means the object does not
-	// exist.
-	DstGenerationPrecondition int64
 }
 
 // MaxSourcesPerComposeRequest is the maximum number of sources that a

--- a/gcs/requests.go
+++ b/gcs/requests.go
@@ -162,13 +162,14 @@ type ComposeSource struct {
 //
 // Its semantics are as follows:
 //
-//   - If Limit is less than or equal to Start, the range is treated as empty.
+//  *  If Limit is less than or equal to Start, the range is treated as empty.
 //
-//   - The effective range is [start, limit) intersected with [0, L), where L
+//  *  The effective range is [start, limit) intersected with [0, L), where L
 //     is the length of the object.
 //
 //     For example, a read for [L-1, L+10) returns the last byte of the object,
 //     and [L+2, L+10) is legal but returns nothing.
+//
 type ByteRange struct {
 	Start uint64
 	Limit uint64

--- a/gcs/requests.go
+++ b/gcs/requests.go
@@ -90,6 +90,11 @@ type CopyObjectRequest struct {
 	//
 	// This is probably only meaningful in conjunction with SrcGeneration.
 	SrcMetaGenerationPrecondition *int64
+
+	// Destination object will be overwritten only if the current
+	// generation is equal to the given value. Zero means the object does not
+	// exist.
+	DstGenerationPrecondition int64
 }
 
 // MaxSourcesPerComposeRequest is the maximum number of sources that a

--- a/gcs/requests.go
+++ b/gcs/requests.go
@@ -94,7 +94,7 @@ type CopyObjectRequest struct {
 	// Destination object will be overwritten only if the current
 	// generation is equal to the given value. Zero means the object does not
 	// exist.
-	DstGenerationPrecondition int64
+	DstGenerationPrecondition *int64
 }
 
 // MaxSourcesPerComposeRequest is the maximum number of sources that a
@@ -162,14 +162,13 @@ type ComposeSource struct {
 //
 // Its semantics are as follows:
 //
-//  *  If Limit is less than or equal to Start, the range is treated as empty.
+//   - If Limit is less than or equal to Start, the range is treated as empty.
 //
-//  *  The effective range is [start, limit) intersected with [0, L), where L
+//   - The effective range is [start, limit) intersected with [0, L), where L
 //     is the length of the object.
 //
 //     For example, a read for [L-1, L+10) returns the last byte of the object,
 //     and [L+2, L+10) is legal but returns nothing.
-//
 type ByteRange struct {
 	Start uint64
 	Limit uint64

--- a/gcs/requests.go
+++ b/gcs/requests.go
@@ -94,7 +94,7 @@ type CopyObjectRequest struct {
 	// Destination object will be overwritten only if the current
 	// generation is equal to the given value. Zero means the object does not
 	// exist.
-	DstGenerationPrecondition *int64
+	DstGenerationPrecondition int64
 }
 
 // MaxSourcesPerComposeRequest is the maximum number of sources that a
@@ -162,13 +162,14 @@ type ComposeSource struct {
 //
 // Its semantics are as follows:
 //
-//   - If Limit is less than or equal to Start, the range is treated as empty.
+//  *  If Limit is less than or equal to Start, the range is treated as empty.
 //
-//   - The effective range is [start, limit) intersected with [0, L), where L
+//  *  The effective range is [start, limit) intersected with [0, L), where L
 //     is the length of the object.
 //
 //     For example, a read for [L-1, L+10) returns the last byte of the object,
 //     and [L+2, L+10) is legal but returns nothing.
+//
 type ByteRange struct {
 	Start uint64
 	Limit uint64

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jacobsa/gcloud
 
-go 1.18
+go 1.17
 
 require (
 	github.com/jacobsa/fuse v0.0.0-20211125163655-ffd6c474e806

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jacobsa/gcloud
 
-go 1.17
+go 1.18
 
 require (
 	github.com/jacobsa/fuse v0.0.0-20211125163655-ffd6c474e806


### PR DESCRIPTION
This parameter is required to set preconditions on the destination object for copy flow.