### PR TITLE
Updating go version 1.19 to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jacobsa/gcloud
 
-go 1.19
+go 1.20
 
 require (
 	github.com/jacobsa/fuse v0.0.0-20211125163655-ffd6c474e806


### PR DESCRIPTION
These changes are required for upgrading go to 1.19 in GCSFuse: https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/go.mod

To fix this issue - https://github.com/GoogleCloudPlatform/gcsfuse/issues/1071