### PR TITLE
upgrade to go version 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jacobsa/gcloud
 
-go 1.20
+go 1.21
 
 require (
 	github.com/jacobsa/fuse v0.0.0-20211125163655-ffd6c474e806


### PR DESCRIPTION
upgrade go version to 1.21 to fix vulnerabilities https://github.com/GoogleCloudPlatform/gcsfuse/issues/1288